### PR TITLE
dysplay dockerImageUri at the end of obdr

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -293,4 +293,11 @@ push <- function(url, file="component.amc", token, create=TRUE, license, headers
                 do.call(httr::add_headers, headers), encode="multipart")
     if (http_error(req)) stop("HTTP error in the POST request: ", content(req))
     invisible(content(req))
+    
+    if (content(req)$status=="SUCCESS") {
+                cat("Model pushed successfully to :",url,"\n")
+                if(headers[["isCreateMicroservice"]]=="true") {cat("Acumos model docker image successfully created :",content(req)$dockerImageUri,"\n")
+		}
+
+
 }


### PR DESCRIPTION
The goal here is to give better feedback to the Acumos user when CLI on-boarding is used 

- dysplay successfull message
- dysplay dockerImageUri 
